### PR TITLE
Add better error reasons

### DIFF
--- a/lib/message_media_messages/exceptions/api_exception.rb
+++ b/lib/message_media_messages/exceptions/api_exception.rb
@@ -10,8 +10,13 @@ module MessageMediaMessages
     # @param [String] reason The reason for raising an exception.
     # @param [HttpContext] context The HttpContext of the API call.
     def initialize(reason, context)
-      super(reason)
       @context = context
+      begin
+        json_body = JSON.parse(@context.response.raw_body)
+        reason = json_body["message"] + ": " + json_body["details"]
+      rescue StandardError => e
+      end
+      super(reason)
       @response_code = context.response.status_code
     end
   end

--- a/lib/message_media_messages/exceptions/api_exception.rb
+++ b/lib/message_media_messages/exceptions/api_exception.rb
@@ -13,7 +13,7 @@ module MessageMediaMessages
       @context = context
       begin
         json_body = JSON.parse(@context.response.raw_body)
-        reason = json_body["message"] + ": " + json_body["details"]
+        reason = json_body["message"] + ": " + json_body["details"].join(", ")
       rescue StandardError => e
       end
       super(reason)


### PR DESCRIPTION
Current error messages dont display what the error was. This will extract the error message from the response if provided an make debugging errors much easier.

An alternative approach could be to put the code where the error is generated instead: lib/message_media_messages/controllers/messages_controller.rb#L345

Example before:
<img width="1262" alt="screen shot 2018-06-05 at 4 12 33 pm" src="https://user-images.githubusercontent.com/501033/40959266-575075fa-68db-11e8-9373-ab549726687c.png">

Example after:
<img width="1260" alt="screen shot 2018-06-05 at 4 12 47 pm" src="https://user-images.githubusercontent.com/501033/40959275-5a7a49cc-68db-11e8-8c87-c3de8de5c841.png">

