### PR TITLE
Relax faraday version

### DIFF
--- a/message_media_messages.gemspec
+++ b/message_media_messages.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://developers.messagemedia.com'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.0')
-  s.add_dependency('faraday', '~> 0.10.0')
+  s.add_dependency('faraday', '~> 0.10')
   s.add_dependency('test-unit', '~> 3.1.5')
   s.add_dependency('certifi', '~> 2016.9', '>= 2016.09.26')
   s.add_dependency('faraday-http-cache', '~> 1.2', '>= 1.2.2')


### PR DESCRIPTION
Fixes #14 
Currently the dependency on faraday is restricted to `0.10.x`. Since this version is now quite outdated, this makes it tricky to use this gem in an app with other dependencies that have a minimum version that is higher than this.

This PR relaxes this restriction to allow `0.x` versions of faraday. Faraday `1.x` is now released, and the `0.x` versions strive to maintain api compatibility between them.