### PR TITLE
Allow any point release of faraday before `1.0.0`

### DIFF
--- a/message_media_messages.gemspec
+++ b/message_media_messages.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'messagemedia_messages_sdk'
-  s.version = '2.0.0'
+  s.version = '2.0.1'
   s.summary = 'MessageMedia Messages SDK'
   s.description = 'The MessageMedia Messages API provides a number of endpoints for building powerful two-way messaging applications.'
   s.authors = ['MessageMedia Developers']
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://developers.messagemedia.com'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.0')
-  s.add_dependency('faraday', '~> 0.10.0')
+  s.add_dependency('faraday', '~> 0.10')
   s.add_dependency('test-unit', '~> 3.1.5')
   s.add_dependency('certifi', '~> 2016.9', '>= 2016.09.26')
   s.add_dependency('faraday-http-cache', '~> 1.2', '>= 1.2.2')


### PR DESCRIPTION
As a consumer of this SDK, our stack includes a newer version of Faraday which is not in the `~>0.10.0` range.  This PR slightly relaxes the required versions of the Faraday dependency to bring it up to anything `< 1.0`.  Sending an SMS message has been tested working against `0.17.3`, which is the latest version before the `1.0.0` release