### PR TITLE
Bump faraday and faraday-http-cache gem versions

### DIFF
--- a/message_media_messages.gemspec
+++ b/message_media_messages.gemspec
@@ -8,10 +8,10 @@ Gem::Specification.new do |s|
   s.homepage = 'https://developers.messagemedia.com'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.0')
-  s.add_dependency('faraday', '~> 0.10')
+  s.add_dependency('faraday', '~> 2.0')
   s.add_dependency('test-unit', '~> 3.1.5')
   s.add_dependency('certifi', '~> 2016.9', '>= 2016.09.26')
-  s.add_dependency('faraday-http-cache', '~> 1.2.2')
+  s.add_dependency('faraday-http-cache', '~> 2.0')
   s.required_ruby_version = '>= 2.0.0'
   s.files = Dir['{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']


### PR DESCRIPTION
`faraday` and `faraday-http-cache` are a bit on the older side and could need an update.