### PR TITLE
Upgrade Faraday to 2.x and adapt gem to Ruby >= 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
     steps:
       - name: Checkout messages-ruby-sdk
         uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          
+
       - name: Build gem
         run: gem build *.gemspec
 
@@ -65,7 +65,7 @@ jobs:
       #    printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
       #    gem build *.gemspec
       #    gem push *.gem
-          
+
       - name: Publish to GPR
         run: |
          mkdir -p $HOME/.gem

--- a/lib/message_media_messages.rb
+++ b/lib/message_media_messages.rb
@@ -5,8 +5,10 @@
 
 require 'date'
 require 'json'
+require 'cgi/escape'
 require 'faraday'
-require 'certifi'
+require 'faraday/multipart'
+require 'faraday/retry'
 require 'logging'
 
 require_relative 'message_media_messages/api_helper.rb'

--- a/lib/message_media_messages/http/faraday_client.rb
+++ b/lib/message_media_messages/http/faraday_client.rb
@@ -15,7 +15,6 @@ module MessageMediaMessages
         faraday.use Faraday::HttpCache, serializer: Marshal if cache
         faraday.request :multipart
         faraday.request :url_encoded
-        faraday.ssl[:ca_file] = Certifi.where
         faraday.options[:params_encoder] = Faraday::FlatParamsEncoder
         faraday.options[:open_timeout] = timeout if timeout
         faraday.request :retry, max: max_retries, interval: if max_retries &&

--- a/lib/message_media_messages/models/cancel_scheduled_message_request.rb
+++ b/lib/message_media_messages/models/cancel_scheduled_message_request.rb
@@ -26,7 +26,7 @@ module MessageMediaMessages
       return nil unless hash
 
       # Extract variables from the hash.
-      status = hash['status'] ||= 'cancelled'
+      status = hash['status'].nil? ? 'cancelled' : hash['status']
 
       # Create object from extracted values.
       CancelScheduledMessageRequest.new(status)

--- a/lib/message_media_messages/models/get_message_status_response.rb
+++ b/lib/message_media_messages/models/get_message_status_response.rb
@@ -116,7 +116,7 @@ module MessageMediaMessages
       callback_url = hash['callback_url']
       content = hash['content']
       destination_number = hash['destination_number']
-      delivery_report = hash['delivery_report'] ||= false
+      delivery_report = hash['delivery_report'].nil? ? false : hash['delivery_report']
       format = hash['format']
       message_expiry_timestamp = APIHelper.rfc3339(hash['message_expiry_timestamp']) if
         hash['message_expiry_timestamp']

--- a/lib/message_media_messages/models/message.rb
+++ b/lib/message_media_messages/models/message.rb
@@ -133,7 +133,7 @@ module MessageMediaMessages
       content = hash['content']
       destination_number = hash['destination_number']
       callback_url = hash['callback_url']
-      delivery_report = hash['delivery_report'] ||= false
+      delivery_report = hash['delivery_report'].nil? ? false : hash['delivery_report']
       format = hash['format']
       message_expiry_timestamp = APIHelper.rfc3339(hash['message_expiry_timestamp']) if
         hash['message_expiry_timestamp']

--- a/message_media_messages.gemspec
+++ b/message_media_messages.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'messages-ruby-sdk'
-  s.version = '3.0.0'
+  s.version = '4.0.0'
   s.summary = 'MessageMedia Messages SDK'
   s.description = 'The MessageMedia Messages API provides a number of endpoints for building powerful two-way messaging applications.'
   s.authors = ['MessageMedia Developers']
@@ -8,11 +8,11 @@ Gem::Specification.new do |s|
   s.homepage = 'https://developers.messagemedia.com'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.0')
-  s.add_dependency('faraday', '~> 0.10')
-  s.add_dependency('test-unit', '~> 3.1.5')
-  s.add_dependency('certifi', '~> 2016.9', '>= 2016.09.26')
-  s.add_dependency('faraday-http-cache', '~> 1.2.2')
-  s.required_ruby_version = '>= 2.0.0'
+  s.add_dependency('faraday', '~> 2.0')
+  s.add_dependency('faraday-multipart', '~> 1.0')
+  s.add_dependency('faraday-retry', '~> 2.0')
+  s.add_dependency('faraday-http-cache', '~> 2.5')
+  s.required_ruby_version = '>= 2.6'
   s.files = Dir['{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
- Replace faraday ~> 0.17.0 with ~> 2.0; add faraday-multipart and faraday-retry for middleware extracted from Faraday's core in 2.0
- Upgrade faraday-http-cache from 1.x to 2.5
- Remove certifi (2016-era CA bundle); system SSL via net_http suffices
- Require cgi/escape explicitly for Ruby 4.0 stdlib reduction
- Extend CI matrix to include Ruby 3.2, 3.3, 3.4, and 4.0
- Minimal Ruby version supported by Faraday 2.x is 2.6, so using that as well